### PR TITLE
Use ocaml-migrate-parsetree

### DIFF
--- a/demos/Makefile.rule
+++ b/demos/Makefile.rule
@@ -43,11 +43,11 @@ GENERATED_MOC += moc_$(1).o
 GENERATED_OBJS += moc_$(1).o $(1)_c.o
 $(1).h: $(1).ml
 	$(V)PATH=../../ppx/:$$$$PATH OCAMLPATH=../../lib/_build/bundle \
-	$(OCAMLOPT) -c -ppx "$(PPX_QT) -destdir . -ext cpp" $(1).ml
+	$(OCAMLOPT) -c -ppx "$(PPX_QT) --as-ppx -destdir . -ext cpp" $(1).ml
 
 $(1).cmx: $(1).ml
 	$(V)PATH=../../ppx/:$$$$PATH OCAMLPATH=../../lib/_build/bundle \
-	$(OCAMLOPT) -c -ppx "$(PPX_QT) -nocpp" $(1).ml
+	$(OCAMLOPT) -c -ppx "$(PPX_QT) --as-ppx -nocpp" $(1).ml
 
 $(1)_c.o: $(1)_c.cpp
 	$(V)$(CXX) $(CXXFLAGS) -Dprotected=public -I`ocamlfind c -where` \

--- a/ppx/_tags
+++ b/ppx/_tags
@@ -1,1 +1,1 @@
-true: package(compiler-libs.common,unix)
+true: package(compiler-libs.common,unix,ocaml-migrate-parsetree)

--- a/ppx/ppxext/ppx_qt.ml
+++ b/ppx/ppxext/ppx_qt.ml
@@ -398,4 +398,5 @@ let mapper =
 
 let () =
   Driver.register ~name:"ppx_qt" ~args Versions.ocaml_403
-    (fun _config _cookies -> mapper)
+    (fun _config _cookies -> mapper);
+  Driver.run_main ()


### PR DESCRIPTION
This allows us to not worry about keeping the ppx code up to date. For example, the ppx as of now supports only 4.03.