### PR TITLE
Fix configure version checks

### DIFF
--- a/configure
+++ b/configure
@@ -6,7 +6,7 @@ NC='\033[0m'      # No Color
 echo "N.B. Don't forget to export right LD_LIBRARY_PATH and PKG_CONFIG_PATH for Qt5 before running this!"
 
 function verlte() {
-    [ "$1" = "`printf "$1\n$2\n" | sort | head -n1`" ]
+    [ "$1" == "$2" ] || test "$(printf '%s\n' "$@" | sort -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4 -n | head -n 1)" != "$2"
 }
 
 function maybe_exit() {


### PR DESCRIPTION
Previous version doesn't work with more one digits in subparts.
Function based on https://stackoverflow.com/a/24067243

Fixes my issue, where I have Qt 5.10.0 but current configure things that is smaller than 5.2.0.