### PR TITLE
Check result of dynamic cast

### DIFF
--- a/lib/stubs/startup_stubs.cpp
+++ b/lib/stubs/startup_stubs.cpp
@@ -278,7 +278,8 @@ extern "C" value caml_run_QQmlApplicationEngine(value _argv, value _cb, value _q
   if (xs.count() == 0) {
     Q_ASSERT_X(false, "Creating C++ runtime", "Your QML file seems buggy");
   }
-  QQuickWindow *window = qobject_cast<QQuickWindow*>(xs.at(0) );
+  QQuickWindow *window = qobject_cast<QQuickWindow*>(xs.at(0));
+  Q_ASSERT_X(window != nullptr, "Creating C++ runtime", "Couldn't cast root object to QQuickWindow");
   window->show();
   //qDebug() << "executing app.exec()";
   app.exec();


### PR DESCRIPTION
This cast is failing on my phone running SailfishOS (Qt 5.6.13), so the current version segfaults. I'm not sure why, going through `Labqml.create_app_engine` and `QQuickWindow.show` works fine (yay for writing phone apps in OCaml). This just asserts that the cast worked.