### PR TITLE
Remove install entry from .opam file

### DIFF
--- a/lablqml.opam
+++ b/lablqml.opam
@@ -17,10 +17,6 @@ build: [
                              { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
   [make "demos"] { with-test & os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" } 
 ]
-install: [
-  ["sh" "-exc" "PATH=/usr/lib64/qt5/bin:/usr/lib/qt5/bin:$PATH make install"]       { os-distribution  = "alpine" | os-distribution  = "centos" | os-distribution  = "fedora" }
-  [make "install"]                                                                  { os-distribution != "alpine" & os-distribution != "centos" & os-distribution != "fedora" }
-]
 remove: [make "uninstall"]
 flags: [ light-uninstall ]
 depends: [


### PR DESCRIPTION
Apparently keeping it makes dune angry, and removing it still installs the package.

See https://github.com/Kakadu/lablqml/issues/62#issuecomment-581592173